### PR TITLE
+date type MongoDate

### DIFF
--- a/org/bsonspec/BSONDecoder.hx
+++ b/org/bsonspec/BSONDecoder.hx
@@ -69,7 +69,7 @@ class BSONDecoder
 			case 0x09: // utc datetime (int64)
         var d_low = input.readInt32();
         var d_high = input.readInt32();
-        value = new BSONDate(Int64.make(d_high, d_low));
+        value = new MongoDate(Int64.make(d_high, d_low));
 				bytes += 8;
 			case 0x0A: // null
 				value = null;

--- a/org/bsonspec/MongoDate.hx
+++ b/org/bsonspec/MongoDate.hx
@@ -4,7 +4,7 @@ import haxe.Int64;
 using haxe.Int64;
 
 
-class BSONDate
+class MongoDate
 {
   public var utc_ms:Int64;
   public var date:Date;


### PR DESCRIPTION
There was bug and here is better support for date type.
This pull request includes better class name BSONDate -> MongoDate
