### PR TITLE
Fix dates

### DIFF
--- a/org/bsonspec/BSONDecoder.hx
+++ b/org/bsonspec/BSONDecoder.hx
@@ -67,10 +67,9 @@ class BSONDecoder
 				value = (input.readByte() == 1) ? true : false;
 				bytes += 1;
 			case 0x09: // utc datetime (int64)
-        var d_low = input.readInt32();
-        var d_high = input.readInt32();
-        value = new MongoDate(Int64.make(d_high, d_low));
+				var date = (readInt64(input) : MongoDate);
 				bytes += 8;
+				value = date;
 			case 0x0A: // null
 				value = null;
 			case 0x0B: // regular expression

--- a/org/bsonspec/BSONEncoder.hx
+++ b/org/bsonspec/BSONEncoder.hx
@@ -68,8 +68,10 @@ class BSONEncoder
 		}
 		else if (Std.is(value, Date))
 		{
+			var d64 = (value : MongoDate).getTimeInt64();
 			writeHeader(out, key, 0x09);
-			out.writeDouble(value.getTime());
+			out.writeInt32(Int64.getLow(d64));
+			out.writeInt32(Int64.getHigh(d64));
 		}
 		else if (Std.is(value, Array))
 		{

--- a/test/BSONTest.hx
+++ b/test/BSONTest.hx
@@ -2,8 +2,10 @@ import haxe.Int64;
 import haxe.unit.TestCase;
 import org.bsonspec.BSON;
 import org.bsonspec.BSONDocument;
+import org.bsonspec.MongoDate;
 import org.bsonspec.ObjectID;
 import sys.io.File;
+using haxe.Int64;
 
 class BSONTest extends TestCase
 {
@@ -26,6 +28,7 @@ class BSONTest extends TestCase
 					}
 				]
 			},
+			date: Date.now(),
 			monkey: null
 		};
 		File.saveBytes("test.bson", BSON.encode(data));
@@ -62,6 +65,37 @@ class BSONTest extends TestCase
 		File.saveContent("test-doc.txt", doc.toString() );
 
 		var out:Dynamic = BSON.decode(File.read("test.bson", true));
+	}
+
+	@:access(org.bsonspec.MongoDate)
+	function testMongoDate()
+	{
+		function log2(v:Float)
+		{
+			return Math.log(v)/Math.log(2);
+		}
+
+		function test(high:Int, low:Int)
+		{
+			var date = (Int64.make(high, low) : MongoDate);
+			var cal = date.getTimeInt64();
+			assertEquals(high, cal.getHigh());
+#if neko  // on neko Date has 1000 ms precision
+			assertEquals(Math.floor(low/1000), Math.floor(cal.getLow()/1000));
+#else
+			// assertEquals(Math.floor(low/100), Math.floor(cal.getLow()/100));
+			// assertEquals(Math.floor(low/10), Math.floor(cal.getLow()/10));
+			assertEquals(low, cal.getLow());
+#end
+		}
+
+		test(0, 1000);  // 1 second
+		test(0, 0x7fffffff);
+		test(0, 0xffffffff);
+		test(0, 1000*3600*24);  // 1 day
+		test(0x007, 0x57B12C00);  // 365 days
+		test(0x148, 0xED0DAAE8);  // some time at 7 Oct 2014
+		test(0x148, 0xED203CD0);  // some other time at 7 Oct 2014
 	}
 
 }

--- a/test/MongoTest.hx
+++ b/test/MongoTest.hx
@@ -28,7 +28,9 @@ class MongoTest extends TestCase
 				obj: {
 					updated: Date.now(),
 					bool: true
-				}
+				},
+                setDate: Date.fromTime(1e10),
+                postDate: Date.now()
 			});
 		}
 		posts.insert(data);
@@ -60,6 +62,7 @@ class MongoTest extends TestCase
 	{
 		var obj = posts.findOne();
 		assertTrue(obj.title == 'My awesome post');
+        assertEquals(obj.setDate.getTime(), 1e10);
 	}
 
 	public function testLogin()


### PR DESCRIPTION
Besides the Int64 endianess fix, Date -> Int64 was missing, MongoDate abstract over Date.

The implementation over an abstract avoids the need to duplicate encoding behaviour for Date and MongoDate.
