### PR TITLE
Make Cursor an Iterable

### DIFF
--- a/org/mongodb/Cursor.hx
+++ b/org/mongodb/Cursor.hx
@@ -57,6 +57,11 @@ class Cursor
 		return documents.shift();
 	}
 
+	public function iterator():Iterator<Dynamic>
+	{
+		return this;
+	}
+
 	private var collection:String;
 	private var cursorId:Int64;
 	private var documents:Array<Dynamic>;

--- a/test/MongoTest.hx
+++ b/test/MongoTest.hx
@@ -58,6 +58,12 @@ class MongoTest extends TestCase
 		assertTrue(count == NUM_POSTS);
 	}
 
+	public function testIterable()
+	{
+		var count = Lambda.fold(posts.find(), function (_, cnt) return cnt+1, 0);
+		assertEquals(NUM_POSTS, count);
+	}
+
 	public function testData()
 	{
 		var obj = posts.findOne();


### PR DESCRIPTION
This allows the use of expressions like `Lambda.map(col.find()...)`.