### PR TITLE
Use instances of Protocol instead of statics

### DIFF
--- a/org/mongodb/Collection.hx
+++ b/org/mongodb/Collection.hx
@@ -7,34 +7,35 @@ class Collection
 		this.name = name;
 		this.fullname = db.name + "." + name;
 		this.db = db;
+		this.cnx = db.mongo.cnx;
 	}
 
 	public inline function find(?query:Dynamic, ?returnFields:Dynamic, skip:Int = 0, number:Int = 0):Cursor
 	{
-		Protocol.query(fullname, query, returnFields, skip, number);
-		return new Cursor(fullname);
+		cnx.query(fullname, query, returnFields, skip, number);
+		return new Cursor(this);
 	}
 
 	public inline function findOne(?query:Dynamic, ?returnFields:Dynamic):Dynamic
 	{
-		Protocol.query(fullname, query, returnFields, 0, -1);
-		return Protocol.getOne();
+		cnx.query(fullname, query, returnFields, 0, -1);
+		return cnx.getOne();
 	}
 
 	public inline function insert(fields:Dynamic):Void
 	{
-		Protocol.insert(fullname, fields);
+		cnx.insert(fullname, fields);
 	}
 
 	public inline function update(select:Dynamic, fields:Dynamic, ?upsert:Bool, ?multi:Bool):Void
 	{
 		var flags = 0x0 | (upsert ? 0x1 : 0) | (multi ? 0x2 : 0);
-		Protocol.update(fullname, select, fields, flags);
+		cnx.update(fullname, select, fields, flags);
 	}
 
 	public inline function remove(?select:Dynamic):Void
 	{
-		Protocol.remove(fullname, select);
+		cnx.remove(fullname, select);
 	}
 
 	public inline function create():Void { db.createCollection(name); }
@@ -43,8 +44,8 @@ class Collection
 
 	public function getIndexes():Cursor
 	{
-		Protocol.query(db.name + ".system.indexes", {ns: fullname});
-		return new Cursor(fullname);
+		cnx.query(db.name + ".system.indexes", {ns: fullname});
+		return new Cursor(this);
 	}
 
 	public function ensureIndex(keyPattern:Dynamic, ?options:Dynamic):Void
@@ -68,7 +69,7 @@ class Collection
 			Reflect.setField(options, "key", keyPattern);
 		}
 
-		Protocol.insert(db.name + ".system.indexes", options);
+		cnx.insert(db.name + ".system.indexes", options);
 	}
 
 	public function dropIndexes():Void
@@ -103,6 +104,7 @@ class Collection
 
 	public var fullname(default, null):String;
 	public var name(default, null):String;
-	private var db:Database;
-
+	public var db(default, null):Database;
+	private var cnx:Protocol;
 }
+

--- a/org/mongodb/Cursor.hx
+++ b/org/mongodb/Cursor.hx
@@ -4,10 +4,10 @@ import haxe.Int64;
 
 class Cursor
 {
-
-	public function new(collection:String)
+	public function new(collection:Collection)
 	{
 		this.collection = collection;
+		this.cnx = collection.db.mongo.cnx;
 		this.finished = false;
 		this.documents = new Array<Dynamic>();
 
@@ -16,13 +16,13 @@ class Cursor
 
 	private inline function checkResponse():Bool
 	{
-		cursorId = Protocol.response(documents);
+		cursorId = cnx.response(documents);
 		if (documents.length == 0)
 		{
 			finished = true;
 			if (cursorId != null)
 			{
-				Protocol.killCursors([cursorId]);
+				cnx.killCursors([cursorId]);
 			}
 			return false;
 		}
@@ -43,7 +43,7 @@ class Cursor
 		}
 		else
 		{
-			Protocol.getMore(collection, cursorId);
+			cnx.getMore(collection.fullname, cursorId);
 			if (checkResponse())
 			{
 				return true;
@@ -57,9 +57,10 @@ class Cursor
 		return documents.shift();
 	}
 
-	private var collection:String;
+	private var collection(default, null):Collection;
+	private var cnx:Protocol;
 	private var cursorId:Int64;
 	private var documents:Array<Dynamic>;
 	private var finished:Bool;
-
 }
+

--- a/org/mongodb/Database.hx
+++ b/org/mongodb/Database.hx
@@ -9,9 +9,10 @@ import org.bsonspec.BSONDocument;
 
 class Database implements Dynamic<Collection>
 {
-	public function new(name:String)
+	public function new(name:String, mongo:Mongo)
 	{
 		this.name = name;
+		this.mongo = mongo;
 		this.cmd = new Collection("$cmd", this);
 	}
 
@@ -123,5 +124,7 @@ class Database implements Dynamic<Collection>
 	}
 
 	public var name(default, null):String;
+	public var mongo(default, null):Mongo;
 	private var cmd:Collection;
 }
+

--- a/org/mongodb/Mongo.hx
+++ b/org/mongodb/Mongo.hx
@@ -2,15 +2,14 @@ package org.mongodb;
 
 class Mongo implements Dynamic<Database>
 {
-
 	public function new(?host:String = "localhost", ?port:Int = 27017)
 	{
-		Protocol.connect(host, port);
+		cnx = Protocol.open(host, port);
 	}
 
 	public inline function getDB(name:String):Database
 	{
-		return new Database(name);
+		return new Database(name, this);
 	}
 
 	public function resolve(name:String):Database
@@ -18,8 +17,12 @@ class Mongo implements Dynamic<Database>
 		return getDB(name);
 	}
 
-    public function close() {
-        Protocol.close();
-    }
+	public function close() {
+		cnx.close();
+	}
 
+	@:allow(org.mongodb.Collection)
+	@:allow(org.mongodb.Cursor)
+	private var cnx:Protocol;
 }
+


### PR DESCRIPTION
 - Allows multiple connections
 - Improves the development of Cursor methods such as .limit() and
   .sort()
    - Each Cursor instance already receives (indirectly) a Protocol
      instance
    - The Cursor methods will each return new Cursor instances