### PR TITLE
Some improvements

### DIFF
--- a/org/bsonspec/BSONDecoder.hx
+++ b/org/bsonspec/BSONDecoder.hx
@@ -55,7 +55,7 @@ class BSONDecoder
 			case 0x05: // binary data
 				var len = readInt32(input);
 				var subtype = input.readByte();
-				// TODO: properly handle binary data
+				value = haxe.io.Bytes.alloc( len );
 				input.readBytes(value, 0, len);
 				bytes += len + 5;
 			case 0x06: // DBPointer

--- a/org/bsonspec/BSONEncoder.hx
+++ b/org/bsonspec/BSONEncoder.hx
@@ -50,15 +50,22 @@ class BSONEncoder
 			writeHeader(out, key, 0x02);
 			writeString(out, value);
 		}
-		else if (Std.is(value, Float))
+		else if (Std.is(value, haxe.io.Bytes))
 		{
-			writeHeader(out, key, 0x01);
-			out.writeDouble(value);
+			writeHeader(out, key, 0x05);
+			out.writeInt32(value.length);
+			out.writeByte(0x00); // generic
+			out.writeBytes(value, 0, value.length);
 		}
 		else if (Std.is(value, Int))
 		{
 			writeHeader(out, key, 0x10);
 			out.writeInt32(#if haxe3 value #else haxe.Int32.ofInt(value) #end);
+		}
+		else if (Std.is(value, Float))
+		{
+			writeHeader(out, key, 0x01);
+			out.writeDouble(value);
 		}
 		else if (Std.is(value, Int64))
 		{

--- a/org/bsonspec/BSONEncoder.hx
+++ b/org/bsonspec/BSONEncoder.hx
@@ -33,82 +33,79 @@ class BSONEncoder
 		var out:BytesOutput = new BytesOutput();
 		var bytes:Bytes;
 
-		if (value == null)
+		switch( Type.typeof(value) )
 		{
-			writeHeader(out, key, 0x0A);
-		}
-		else if (Std.is(value, Bool))
-		{
-			writeHeader(out, key, 0x08);
-			if (value == true)
-				out.writeByte(0x01);
-			else
-				out.writeByte(0x00);
-		}
-		else if (Std.is(value, String))
-		{
-			writeHeader(out, key, 0x02);
-			writeString(out, value);
-		}
-		else if (Std.is(value, haxe.io.Bytes))
-		{
-			writeHeader(out, key, 0x05);
-			out.writeInt32(value.length);
-			out.writeByte(0x00); // generic
-			out.writeBytes(value, 0, value.length);
-		}
-		else if (Std.is(value, Int))
-		{
-			writeHeader(out, key, 0x10);
-			out.writeInt32(#if haxe3 value #else haxe.Int32.ofInt(value) #end);
-		}
-		else if (Std.is(value, Float))
-		{
-			writeHeader(out, key, 0x01);
-			out.writeDouble(value);
-		}
-		else if (Std.is(value, Int64))
-		{
-			writeHeader(out, key, 0x12);
-			out.writeInt32(Int64.getLow(value));
-			out.writeInt32(Int64.getHigh(value));
-		}
-		else if (Std.is(value, Date))
-		{
-			var d64 = (value : MongoDate).getTimeInt64();
-			writeHeader(out, key, 0x09);
-			out.writeInt32(Int64.getLow(d64));
-			out.writeInt32(Int64.getHigh(d64));
-		}
-		else if (Std.is(value, Array))
-		{
-			writeHeader(out, key, 0x04);
-			bytes = arrayToBytes(value);
-			out.writeInt32(#if haxe3 bytes.length + 4 #else haxe.Int32.ofInt(bytes.length + 4) #end);
-			out.writeBytes(bytes, 0, bytes.length);
-		}
-		else if (Std.is(value, ObjectID))
-		{
-			writeHeader(out, key, 0x07);
-			out.writeBytes(value.bytes, 0, 12);
-		}
-		else if (Std.is(value, BSONDocument)) // document/object
-		{
-			writeHeader(out, key, 0x03);
-			bytes = documentToBytes(value);
-			out.writeInt32(#if haxe3 bytes.length + 4 #else haxe.Int32.ofInt(bytes.length + 4) #end);
-			out.writeBytes(bytes, 0, bytes.length);
-		}
-		else if (Std.is(value, Dynamic)) // document/object
-		{
-			writeHeader(out, key, 0x03);
-			bytes = objectToBytes(value);
-			out.writeInt32(#if haxe3 bytes.length + 4 #else haxe.Int32.ofInt(bytes.length + 4) #end);
-			out.writeBytes(bytes, 0, bytes.length);
-		}
-		else
-		{
-			trace("could not encode " + Std.string(value));
+			case TNull:
+				writeHeader(out, key, 0x0A);
+			
+			case TInt:
+				writeHeader(out, key, 0x10);
+				out.writeInt32(#if haxe3 value #else haxe.Int32.ofInt(value) #end);
+				
+			case TFloat:
+				writeHeader(out, key, 0x01);
+				out.writeDouble(value);
+			
+			case TBool:
+				writeHeader(out, key, 0x08);
+				out.writeByte( value ? 0x01 : 0x00 );
+			
+			default:
+				if (Std.is(value, String))
+				{
+					writeHeader(out, key, 0x02);
+					writeString(out, value);
+				}
+				else if (Std.is(value, haxe.io.Bytes))
+				{
+					writeHeader(out, key, 0x05);
+					out.writeInt32(value.length);
+					out.writeByte(0x00); // generic
+					out.writeBytes(value, 0, value.length);
+				}
+				else if (Std.is(value, Int64))
+				{
+					writeHeader(out, key, 0x12);
+					out.writeInt32(Int64.getLow(value));
+					out.writeInt32(Int64.getHigh(value));
+				}
+				else if (Std.is(value, Date))
+				{
+					var d64 = (value : MongoDate).getTimeInt64();
+					writeHeader(out, key, 0x09);
+					out.writeInt32(Int64.getLow(d64));
+					out.writeInt32(Int64.getHigh(d64));
+				}
+				else if (Std.is(value, Array))
+				{
+					writeHeader(out, key, 0x04);
+					bytes = arrayToBytes(value);
+					out.writeInt32(#if haxe3 bytes.length + 4 #else haxe.Int32.ofInt(bytes.length + 4) #end);
+					out.writeBytes(bytes, 0, bytes.length);
+				}
+				else if (Std.is(value, ObjectID))
+				{
+					writeHeader(out, key, 0x07);
+					out.writeBytes(value.bytes, 0, 12);
+				}
+				else if (Std.is(value, BSONDocument)) // document/object
+				{
+					writeHeader(out, key, 0x03);
+					bytes = documentToBytes(value);
+					out.writeInt32(#if haxe3 bytes.length + 4 #else haxe.Int32.ofInt(bytes.length + 4) #end);
+					out.writeBytes(bytes, 0, bytes.length);
+				}
+				else if (Std.is(value, Dynamic)) // document/object
+				{
+					writeHeader(out, key, 0x03);
+					bytes = objectToBytes(value);
+					out.writeInt32(#if haxe3 bytes.length + 4 #else haxe.Int32.ofInt(bytes.length + 4) #end);
+					out.writeBytes(bytes, 0, bytes.length);
+				}
+				else
+				{
+					trace("could not encode " + Std.string(value));
+				}
 		}
 
 		return out.getBytes();

--- a/org/bsonspec/BSONEncoder.hx
+++ b/org/bsonspec/BSONEncoder.hx
@@ -60,16 +60,23 @@ class BSONEncoder
 				out.writeByte(0x00); // generic
 				out.writeBytes(value, 0, value.length);
 			
+			#if (haxe_ver < 3.2)
 			case TClass(Int64):
 				writeHeader(out, key, 0x12);
 				out.writeInt32(Int64.getLow(value));
 				out.writeInt32(Int64.getHigh(value));
-			
 			case TClass(Date):
 				var d64 = (value : MongoDate).getTimeInt64();
 				writeHeader(out, key, 0x09);
 				out.writeInt32(Int64.getLow(d64));
 				out.writeInt32(Int64.getHigh(d64));
+			#else 
+			case TClass(Date):
+			var d64 = (value : MongoDate).getTimeInt64();
+			writeHeader(out, key, 0x09);
+			out.writeInt32(d64.low);
+			out.writeInt32(d64.high);
+			#end
 			
 			case TClass(Array):
 				writeHeader(out, key, 0x04);
@@ -88,6 +95,14 @@ class BSONEncoder
 				out.writeBytes(bytes, 0, bytes.length);
 			
 			default:
+				#if haxe_320
+				if ( Int64.is( value )) {
+					writeHeader(out, key, 0x12);
+					out.writeInt32(Int64.getLow(value));
+					out.writeInt32(Int64.getHigh(value));
+				}
+				else 
+				#end
 				if (Std.is(value, Dynamic)) // document/object
 				{
 					writeHeader(out, key, 0x03);

--- a/org/bsonspec/MongoDate.hx
+++ b/org/bsonspec/MongoDate.hx
@@ -36,11 +36,18 @@ abstract MongoDate(Date) {
         return Int64.make(high, low);
     }
 
-    static function unsigned(i:UInt):Float
+    static function unsigned(int):Float
     {
         // conversion peformed by UInt.toFloat()
         // basically, when negative, return POW32f + i
-        return i;
+		if (int < 0) {
+			return 4294967296.0 + int;
+		}
+		else {
+			// + 0.0 here to make sure we promote to Float on some platforms
+			// In particular, PHP was having issues when comparing to Int in the == op.
+			return int + 0.0;
+		}
     }
 
     static var xx = 31;

--- a/org/bsonspec/ObjectID.hx
+++ b/org/bsonspec/ObjectID.hx
@@ -43,6 +43,23 @@ class ObjectID
 	{
 		return Date.fromTime( (bytes.get(3) | (bytes.get(2) << 8) | (bytes.get(1) << 16) | (bytes.get(0) << 24)) * 1000.0 );
 	}
+	
+	public function toHex():String
+	{
+		return bytes.toHex();
+	}
+	
+	public static function ofBytes(bytes:haxe.io.Bytes)
+	{
+		return new ObjectID(new haxe.io.BytesInput(bytes, 0, 12));
+	}
+	
+	public static function ofHex(hex:String)
+	{
+		return new haxe.crypto.BaseCode(HEX).decodeBytes(haxe.io.Bytes.ofString(hex.toLowerCase()));
+	}
+	
+	private static var HEX = haxe.io.Bytes.ofString("0123456789abcdef");
 
 	
 	public var bytes(default, null):Bytes;

--- a/org/bsonspec/ObjectID.hx
+++ b/org/bsonspec/ObjectID.hx
@@ -13,6 +13,9 @@ class ObjectID
 		{
 			// generate a new id
 			var out:BytesOutput = new BytesOutput();
+			
+			// Endianness: https://github.com/mongodb/mongo/blob/master/src/mongo/bson/oid.h
+			out.bigEndian = true;
 #if haxe3
 			out.writeInt32(Math.floor(Date.now().getTime() / 1000)); // seconds
 #else
@@ -37,11 +40,11 @@ class ObjectID
 	}
 
 	public var bytes(default, null):Bytes;
-	private static var sequence:Int = 0;
+	private static var sequence:Int = Std.random(0x1000000);
 
 	// machine host name
 #if (neko || php || cpp)
-	private static var machine:Bytes = Bytes.ofString(sys.net.Host.localhost());
+	private static var machine:Bytes = haxe.crypto.Md5.make(Bytes.ofString(sys.net.Host.localhost()));
 #else
 	private static var machine:Bytes = Bytes.ofString("flash");
 #end

--- a/org/bsonspec/ObjectID.hx
+++ b/org/bsonspec/ObjectID.hx
@@ -56,7 +56,7 @@ class ObjectID
 	
 	public static function ofHex(hex:String)
 	{
-		return new haxe.crypto.BaseCode(HEX).decodeBytes(haxe.io.Bytes.ofString(hex.toLowerCase()));
+		return ofBytes(new haxe.crypto.BaseCode(HEX).decodeBytes(haxe.io.Bytes.ofString(hex.toLowerCase())));
 	}
 	
 	private static var HEX = haxe.io.Bytes.ofString("0123456789abcdef");

--- a/org/bsonspec/ObjectID.hx
+++ b/org/bsonspec/ObjectID.hx
@@ -39,6 +39,12 @@ class ObjectID
 		return 'ObjectID("' + bytes.toHex() + '")';
 	}
 
+	public function getDate():Date
+	{
+		return Date.fromTime( (bytes.get(3) | (bytes.get(2) << 8) | (bytes.get(1) << 16) | (bytes.get(0) << 24)) * 1000.0 );
+	}
+
+	
 	public var bytes(default, null):Bytes;
 	private static var sequence:Int = Std.random(0x1000000);
 

--- a/org/mongodb/Collection.hx
+++ b/org/mongodb/Collection.hx
@@ -85,9 +85,12 @@ class Collection
 		db.runCommand({reIndex: name});
 	}
 
-	public inline function count():Int
+	public inline function count( ?query: Dynamic ):Int
 	{
-		var result = db.runCommand({count: name});
+		var c : {count: String, ?query: Dynamic} = { count: name };
+		if ( query != null )
+			c.query = query;
+		var result = db.runCommand(c);
 		return result.n;
 	}
 

--- a/org/mongodb/Collection.hx
+++ b/org/mongodb/Collection.hx
@@ -99,6 +99,17 @@ class Collection
 		var result = db.runCommand(cmd);
 		return result.values;
 	}
+	
+	public function aggregate( pipeline : Array<Dynamic> ) 
+	{
+		// Use BSONDocument to ensure fields order
+		var bson = new org.bsonspec.BSONDocument();
+		bson.append( "aggregate", name );
+		bson.append( "pipeline", pipeline );
+		var result = db.runCommand( bson );
+		
+		return result;
+	}
 
 	public var fullname(default, null):String;
 	public var name(default, null):String;

--- a/org/mongodb/Cursor.hx
+++ b/org/mongodb/Cursor.hx
@@ -59,6 +59,12 @@ class Cursor
 		}
 		else if (noLimit == 0 || noLimit != noReturn)
 		{
+			// In the event that the result set of the query fits into one OP_REPLY message, cursorID will be 0
+			if ( haxe.Int64.isZero(cursorId) ) {
+				finished = true;
+				return false;
+			}
+
 			cnx.getMore(collection.fullname, cursorId);
 			if (checkResponse())
 			{

--- a/org/mongodb/Database.hx
+++ b/org/mongodb/Database.hx
@@ -122,6 +122,11 @@ class Database implements Dynamic<Collection>
 	{
 		return cmd.findOne({eval: script});
 	}
+	
+	public inline function getLastError():Dynamic 
+	{
+		return runCommand({getLastError: 1});
+	}
 
 	public var name(default, null):String;
 	public var mongo(default, null):Mongo;

--- a/org/mongodb/Protocol.hx
+++ b/org/mongodb/Protocol.hx
@@ -249,8 +249,7 @@ class Protocol
 		}
 		if (flags.has(QueryFailure))
 		{
-			trace(BSON.decode(input));
-			throw "Query failed";
+			throw new QueryException( BSON.decode(input) );
 		}
 
 		return details;

--- a/org/mongodb/QueryException.hx
+++ b/org/mongodb/QueryException.hx
@@ -1,0 +1,28 @@
+package org.mongodb;
+
+class QueryException 
+{
+	
+	private var errorDocument : Dynamic;
+	
+	@:allow(org.mongodb.Protocol)
+	function new( errorDocument :  Dynamic ) {
+		this.errorDocument = errorDocument;
+	}
+	
+	public function getErrorCode()
+	{
+		return errorDocument.code == null ? -1 : errorDocument.code;
+	}
+	
+	public function getErrorMessage() 
+	{
+		return Reflect.field(errorDocument,"$err");
+	}
+	
+	public function toString() 
+	{
+		return "QueryException("+Std.string(errorDocument)+")";
+	}
+	
+}

--- a/test/BSONTest.hx
+++ b/test/BSONTest.hx
@@ -28,15 +28,31 @@ class BSONTest extends TestCase
 				]
 			},
 			date: Date.now(),
-			monkey: null
+			int: 2147483647,
+			float: 2147483647.0,
+			monkey: null,
+			bool: true
 		};
+		
+		#if sys
 		File.saveBytes("test.bson", BSON.encode(data));
 
 		var out = BSON.decode(File.read("test.bson", true));
 
 		File.saveContent("test.txt", Std.string( out ) );
-
+		#else
+		var out = BSON.decode(new haxe.io.BytesInput(BSON.encode(data)));
+		#end
+		
 		assertSame(data, out);
+		
+		// overflow (-2)
+		assertSame(data.int + data.int, out.int + out.int);
+		
+		// no overflow
+		assertSame(data.float + data.float, out.float + out.float);
+		
+		assertSame(data._id.getDate(),  out._id.getDate());
 	}
 
 	function testBSONDocument()


### PR DESCRIPTION
- Throw new QueryException on error (and remove trace)
- Add Database.getLastError()
- Add optional query parameter in Collection.count()
- Add Collection.aggregate()
- Add support for haxe.io.Bytes in BSONEncoder and BSONDecoder
- Use Type.typeof in BSONEncoder (better handling of Int / Float based on native data type)
- Fix encoding of timestamp in ObjectID (use bigEndian)
- Add some ObjectID helpers (getDate, toHex, ofHex, ofBytes)
- Improve ObjectID randomness
- Fix Cursor when cursorID == 0