### PR TITLE
No need for cursorId to ever be null?

### DIFF
--- a/org/mongodb/Cursor.hx
+++ b/org/mongodb/Cursor.hx
@@ -27,10 +27,7 @@ class Cursor<T>
 		if (documents.length == 0)
 		{
 			finished = true;
-			if (cursorId != null)
-			{
-				cnx.killCursors([cursorId]);
-			}
+			cnx.killCursors([cursorId]);
 			return false;
 		}
 		else
@@ -133,7 +130,7 @@ class Cursor<T>
 	private var noReturn:Int;
 	private var noLimit:Int;
 	private var cnx:Protocol;
-	private var cursorId:Null<Int64>;
+	private var cursorId:Int64;
 	private var documents:Array<Dynamic>;
 	private var finished:Bool;
 


### PR DESCRIPTION
This is a change I made to fix a bug I was seeing when using hxcpp to compile this mongodb driver. The error was something like "no 'get' method on the 'Dynamic' cursorId" in Cursor.hx. I'm unfamiliar with hxcpp's source, so I looked into the Cursor.hx and couldn't see a reason why cursorId was typed Null<Int64> since Protocol::response returns only Int64.

I'll work on sorting out a fix for hxcpp as well. Huge thanks for this project!!